### PR TITLE
Improve wkhtmltopdf command composition

### DIFF
--- a/converters/Wkhtmltopdf.php
+++ b/converters/Wkhtmltopdf.php
@@ -52,7 +52,7 @@ class Wkhtmltopdf extends BaseConverter
     {
         $command = $this->binPath;
         foreach ($this->normalizeOptions($options) as $name => $value) {
-            $command .= " --{$name} {$value}";
+            $command .= $this->buildCommandOption($name, $value);
         }
         $command .= ' ' . escapeshellarg($sourceFileName) . ' ' . escapeshellarg($outputFileName);
         $command .= ' 2>&1';
@@ -97,9 +97,27 @@ class Wkhtmltopdf extends BaseConverter
     {
         $result = [];
         foreach ($options as $name => $value) {
+            if (is_null($value) || $value === false) {
+                continue;
+            }
             $normalizedName = Inflector::camel2id($name);
             $result[$normalizedName] = $value;
         }
         return $result;
+    }
+
+    /**
+     * Build option for the shell command composition
+     * @param string $name option name
+     * @param mixed $value option value
+     * @return string option name-value pair
+     */
+    protected function buildCommandOption($name, $value)
+    {
+        $option = " --{$name}";
+        if ($value !== true) {
+            $option .= ' ' . escapeshellarg($value);
+        }
+        return $option;
     }
 }

--- a/converters/Wkhtmltopdf.php
+++ b/converters/Wkhtmltopdf.php
@@ -145,7 +145,17 @@ class Wkhtmltopdf extends BaseConverter
         $option = " {$prefix}{$name}";
 
         if ($value !== true) {
-            $option .= ' ' . escapeshellarg($value);
+            if (is_array($value)) { // Support repeatable options
+                $repeatableOptions = [];
+                foreach ($value as $k => $v) {
+                    $repeatableOptions[] = $option
+                        . (is_string($k) ? ' ' . escapeshellarg($k) : '')
+                        . ' ' .escapeshellarg($v);
+                }
+                $option = implode(' ', $repeatableOptions);
+            } else {
+                $option .= ' ' . escapeshellarg($value);
+            }
         }
         return $option;
     }

--- a/converters/Wkhtmltopdf.php
+++ b/converters/Wkhtmltopdf.php
@@ -31,6 +31,26 @@ class Wkhtmltopdf extends BaseConverter
      */
     public $binPath = 'wkhtmltopdf';
 
+    /**
+     * @var array list of command options aliases.
+     */
+    protected $optionAlias = [
+        'd' => 'dpi',
+        'H' => 'extended-help',
+        'g' => 'grayscale',
+        'h' => 'help',
+        'l' => 'lowquality',
+        'B' => 'margin-bottom',
+        'L' => 'margin-left',
+        'R' => 'margin-right',
+        'T' => 'margin-top',
+        'O' => 'orientation',
+        's' => 'page-size',
+        'q' => 'quiet',
+        'V' => 'version',
+        'n' => 'disable-javascript',
+        'p' => 'proxy',
+    ];
 
     /**
      * {@inheritdoc}
@@ -100,6 +120,9 @@ class Wkhtmltopdf extends BaseConverter
             if (is_null($value) || $value === false) {
                 continue;
             }
+            if (isset($this->optionAlias[$name])) {
+                $name = $this->optionAlias[$name];
+            }
             $normalizedName = Inflector::camel2id($name);
             $result[$normalizedName] = $value;
         }
@@ -114,7 +137,13 @@ class Wkhtmltopdf extends BaseConverter
      */
     protected function buildCommandOption($name, $value)
     {
-        $option = " --{$name}";
+        $prefix = '--';
+        if (in_array($name, ['toc', 'cover'])) { // Don't add '--' in these options
+            $prefix = '';
+        }
+
+        $option = " {$prefix}{$name}";
+
         if ($value !== true) {
             $option .= ' ' . escapeshellarg($value);
         }


### PR DESCRIPTION
. Escapes option value with escapeshellarg();
. Ignore options with false or null value;
. Add support to options without value (e.g. 'disable-smart-shrinking' => true, will be parsed as --disable-smart-shrinking);
. Added Support to option aliases;
. Don't prefix 'toc' and 'cover' options with '--';
. Support repeatable options;