### PR TITLE
Pass PDF options to template on the render function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,44 @@
 {
-    "name": "yii2tech/html2pdf",
-    "description": "Provides support for HTML to PDF and PHP to PDF conversion",
-    "keywords": ["yii2", "html2pdf", "php2pdf", "pdf", "convert", "conversion", "template"],
-    "type": "yii2-extension",
-    "license": "BSD-3-Clause",
-    "support": {
-        "issues": "https://github.com/yii2tech/html2pdf/issues",
-        "forum": "http://www.yiiframework.com/forum/",
-        "wiki": "https://github.com/yii2tech/html2pdf/wiki",
-        "source": "https://github.com/yii2tech/html2pdf"
-    },
-    "authors": [
-        {
-            "name": "Paul Klimov",
-            "email": "klimov.paul@gmail.com"
-        }
-    ],
-    "require": {
-        "yiisoft/yii2": "~2.0.13"
-    },
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
-        }
-    ],
-    "autoload": {
-        "psr-4": { "yii2tech\\html2pdf\\": "src" }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.x-dev"
-        }
-    }
+	"name" : "troncz/html2pdf",
+	"description" : "Provides support for HTML to PDF and PHP to PDF conversion",
+	"keywords" : [
+		"yii2",
+		"html2pdf",
+		"php2pdf",
+		"pdf",
+		"convert",
+		"conversion",
+		"template"
+	],
+	"type" : "yii2-extension",
+	"license" : "BSD-3-Clause",
+	"support" : {
+		"issues" : "https://github.com/yii2tech/html2pdf/issues",
+		"forum" : "http://www.yiiframework.com/forum/",
+		"wiki" : "https://github.com/yii2tech/html2pdf/wiki",
+		"source" : "https://github.com/yii2tech/html2pdf"
+	},
+	"authors" : [{
+			"name" : "Paul Klimov",
+			"email" : "klimov.paul@gmail.com"
+		}
+	],
+	"require" : {
+		"yiisoft/yii2" : "~2.0.13"
+	},
+	"repositories" : [{
+			"type" : "composer",
+			"url" : "https://asset-packagist.org"
+		}
+	],
+	"autoload" : {
+		"psr-4" : {
+			"yii2tech\\html2pdf\\" : "src"
+		}
+	},
+	"extra" : {
+		"branch-alias" : {
+			"dev-master" : "1.0.x-dev"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name" : "troncz/html2pdf",
+	"name" : "yii2tech/html2pdf",
 	"description" : "Provides support for HTML to PDF and PHP to PDF conversion",
 	"keywords" : [
 		"yii2",

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -198,13 +198,14 @@ class Manager extends Component
      * @param array $params the parameters (name-value pairs) that will be extracted and made available in the view file.
      * @return TempFile converted PDF file representation.
      */
-    public function render($view, $params = [])
+    public function render($view, $params = [], $pdfOptions = [])
     {
         $template = new Template([
             'view' => $this->getView(),
             'viewPath' => $this->getViewPath(),
             'viewName' => $view,
             'layout' => $this->layout,
+            'pdfOptions' => $pdfOptions,
         ]);
         $htmlContent = $template->render($params);
 


### PR DESCRIPTION
The PDF options were not available as a parameter on the render command. This simple change fixes that. 
