### PR TITLE
Get file content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii 2 HTML to PDF conversion extension Change Log
 -----------------------
 
 - Bug #12: Fixed inability to setup 'tempDir' and 'fontDir' for `Mpdf` converter (klimov-paul)
-
+- Enh #15: Added method `TempFile::getContent()` (mludvik)
 
 1.0.3, April 9, 2018
 --------------------

--- a/src/TempFile.php
+++ b/src/TempFile.php
@@ -103,6 +103,15 @@ class TempFile extends BaseObject
     }
 
     /**
+     * Gets content of this file.
+     * @return string file content.
+     */
+    public function getContent()
+    {
+        return file_get_contents($this->name);
+    }
+
+    /**
      * Prepares response for sending a file to the browser.
      * Note: this method works only while running web application.
      * @param string $name the file name shown to the user. If null, it will be determined from [[tempName]].

--- a/src/TempFile.php
+++ b/src/TempFile.php
@@ -105,6 +105,7 @@ class TempFile extends BaseObject
     /**
      * Gets content of this file.
      * @return string file content.
+     * @since 1.0.4
      */
     public function getContent()
     {

--- a/tests/TempFileTest.php
+++ b/tests/TempFileTest.php
@@ -68,7 +68,8 @@ class TempFileTest extends TestCase
         $this->assertFalse(file_exists($fileName));
     }
 
-    public function testGetContent() {
+    public function testGetContent()
+    {
         $filePath = $this->ensureTestFilePath();
         $fileName = $filePath . '/test.txt';
         file_put_contents($fileName, 'test content');

--- a/tests/TempFileTest.php
+++ b/tests/TempFileTest.php
@@ -67,4 +67,15 @@ class TempFileTest extends TestCase
         $this->assertTrue(file_exists($destinationFileName));
         $this->assertFalse(file_exists($fileName));
     }
+
+    public function testGetContent() {
+        $filePath = $this->ensureTestFilePath();
+        $fileName = $filePath . '/test.txt';
+        file_put_contents($fileName, 'test content');
+
+        $file = new TempFile();
+        $file->name = $fileName;
+
+        $this->assertEquals('test content', $file->getContent());
+    }
 }


### PR DESCRIPTION
Hi and thanks for this extension :cat: I would like to create pdf and then save it using your another [file-storage](https://github.com/yii2tech/file-storage) extension. Is there already nice way how to do it?

If not, I am proposing this simple new method `getContent`, so that you can do...

```
$content = $html2pdf->convert($html)->getContent();
$bucket->saveFileContent('output.pdf', $content);
```

Thanks for your time :smiley: 