### PR TITLE
Fixed removal on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yii 2 HTML to PDF conversion extension Change Log
 =================================================
 
+1.0.5, December 18, 2018
+-------------------------
+
+- Bug: PHP Warning 'yii\base\ErrorException' with message 'unlink(C:\localhost\api\runtime/html2pdf\html2pdf5c0123789885b0.71556863.pdf): Permission denied' on Windows (AlexRas007)
+
 1.0.4, September 18, 2018
 -------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii 2 HTML to PDF conversion extension Change Log
 1.0.5, December 18, 2018
 -------------------------
 
-- Bug: PHP Warning 'yii\base\ErrorException' with message 'unlink(C:\localhost\api\runtime/html2pdf\html2pdf5c0123789885b0.71556863.pdf): Permission denied' on Windows (AlexRas007)
+- Bug #16: Fixed removal on windows (AlexRas007)
 
 1.0.4, September 18, 2018
 -------------------------

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "~2.0.13"
+        "yiisoft/yii2": "~2.0.14"
     },
     "repositories": [
         {

--- a/src/TempFile.php
+++ b/src/TempFile.php
@@ -95,7 +95,7 @@ class TempFile extends BaseObject
     public function delete()
     {
         if (!empty($this->name) && file_exists($this->name)) {
-            $result = unlink($this->name);
+            $result = FileHelper::unlink($this->name);
             $this->name = null;
             return $result;
         }


### PR DESCRIPTION
**These changes correct this error:**
```
PHP Warning 'yii\base\ErrorException' with message 'unlink(C:\localhost\api\runtime/html2pdf\html2pdf5c0123789885b0.71556863.pdf): Permission denied' 

in C:\localhost\vendor\yii2tech\html2pdf\src\TempFile.php:98
```